### PR TITLE
Mention default React snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 React snippets([live templates](https://www.jetbrains.com/help/idea/2016.1/live-templates.html)) for JetBrains series editors (e.g. WebStorm, PHPStorm, IntelliJ IDEA, etc.), stolen from [sublime-react](https://github.com/reactjs/sublime-react) and [phpstorm-reactjs](https://github.com/geochatz/phpstorm-reactjs).
 
+Alternatively, you can try a collection of React snippets bundled with the IDE (*Preferences/Settings | Editor | Live Templates - React*).
+
 ## Installation
 
 ### Import Automatically


### PR DESCRIPTION
Hi,

Starting with version 2018.2, WebStorm has a collection of React snippets that is based on this [VS Code plugin](https://github.com/xabikos/vscode-react). Many templates are similar to templates in this repo but they are not exactly the same.
I just wanted to let those who are looking for React snippets know that. 
It's totally fine if you decide not to merge this PR. 

Thank you for maintaining this repo! :)